### PR TITLE
Before:

### DIFF
--- a/app.component.css
+++ b/app.component.css
@@ -62,27 +62,26 @@ table {
 
 #menu {
   background-color: black; /*clr 2 menu */
-  height:40px;
+  height:240px;
   /* border: 3px solid blue; */
 }
-
+.foobar {
+  margin: auto;
+  text-align: center; /* children will be ce */
+  width:100%;
+}
 #center_the_menu {
-  /* margin: auto; True Center */
-  margin: 0 0 0 26%; /* Skewed center */
-  width: 40%;
+  margin: auto;
   padding: 0px; 
+  width: 500px;
   text-align: center; /* children will be centered */
-  /* border: 3px solid purple; */
+  border: 3px solid purple; 
 }
 
-#center_the_datepicker {
-  float:left;
-  width:80%;
-}
+
 
 button {
   background-color: rgb(205, 207, 207);
-  position:relative;
   margin: 2px;
 }
 
@@ -178,7 +177,6 @@ button {
   float:left;
   position:relative;
   padding: 5px; 
-  width: 25%;
   /* border: 1px solid green; */
 }
 
@@ -186,7 +184,6 @@ button {
   float:left;
   position:relative;
   padding: 5px; 
-  width: 23%;
   top: -15px;
   /* border: 1px solid green; */
 }

--- a/app.component.html
+++ b/app.component.html
@@ -12,16 +12,18 @@
     </div>
 
     <div id="menu"> 
-      <div  id="center_the_menu">
-        <span id="left-button">
-          <button  (click)="seasonStartDate()">Season Start</button>
-          <button  (click)="decrDate()">-</button>
-        </span>
-        <app-date class="center_the_datepicker" (childEvent)="processChildEvent($event)"></app-date> 
-        <span id="right-button"> 
-          <button  (click)="incrDate()">+</button>
-          <button  (click)="seasonEndDate()">Season End</button>
-        </span>
+      <div class="foobar">
+          <div  id="center_the_menu">
+            <span id="left-button">
+              <button  (click)="seasonStartDate()">Season Start</button>
+              <button  (click)="decrDate()">-</button>
+            </span>
+            <app-date class="center_the_datepicker" (childEvent)="processChildEvent($event)"></app-date> 
+            <span id="right-button"> 
+              <button  (click)="incrDate()">+</button>
+              <button  (click)="seasonEndDate()">Season End</button>
+            </span>
+          </div>
       </div>
     </div>
 


### PR DESCRIPTION
on iphone -- buttons and datepicker were centered and stacked on
top of each other. Looked funky.

After:

on iphone -- buttons and datepicker are on same x-axis, but right most
buttons are "off screen"

The secret to making this improvement:
1) make margin:auto on menu element.
2) make width:100% on menu element.
3) make the width under center_the_menu be 500px instead of 40%.